### PR TITLE
Disconnect SDK player on leave

### DIFF
--- a/src/models/model.js
+++ b/src/models/model.js
@@ -74,6 +74,12 @@ export default {
 		this.playerId = id;
 	},
 
+	removePlayer() {
+		this.player?.disconnect();
+		this.playerLoaded = false;
+		this.player = undefined;
+	},
+
 	setDevice(id, name, volume) {
 		this.device = {
 			active: true,

--- a/src/presenters/controlsPresenter.jsx
+++ b/src/presenters/controlsPresenter.jsx
@@ -20,7 +20,10 @@ export default function controlsPresenter(props) {
 					artist: 'reShuffle.one',
 				});
 		}
-		return () => spotifyPlayerScript.remove();
+		return () => {
+			props.model.removePlayer();
+			spotifyPlayerScript.remove();
+		};
 	}, [props.model.loggedIn]);
 
 	return (

--- a/src/spotifyConnect.js
+++ b/src/spotifyConnect.js
@@ -48,6 +48,14 @@ export default function connectPlayer(model) {
 			}
 		});
 
+		player.addListener('autoplay_failed', ({ message }) => {
+			console.error('Spotify Connect Autoplay Failed:', message);
+		});
+
+		player.addListener('playback_error', ({ message }) => {
+			console.error('Spotify Connect Playback Error:', message);
+		});
+
 		player.connect().then((success) => {
 			if (success) {
 				console.log('Spotify Connect Connected');


### PR DESCRIPTION
Disconnects the SDK player when the player page is left (controlsPresenter is unmounted) and clears it from the model. Fixes so multiple clients shouldn't show up and stay in Spotify Connect.
Also added two new listeners for the SDK player for `autoplay_failed` and `playback_error`.

### How to test
- Go to the player view and check `model.player` and `model.playerLoaded` in the inspector and that it showed up in Spotify Connect.
- Leave the player view, it should now not show up in Spotify Connect and be undefined and unloaded in the model.