### PR TITLE
Add TAB skip content buttons

### DIFF
--- a/src/components/ListScroller.jsx
+++ b/src/components/ListScroller.jsx
@@ -7,11 +7,11 @@ export default function ListScroller(props) {
 	return (
 		<section>
 			<h1>{props.title}</h1>
-			<ul className='list-scroller'>
-				{props.data.map((item) => {
+			<ul className='list-scroller' id={props.id}>
+				{props.data?.map((item) => {
 					return (
 						<li key={item.id}>
-							<img src={item.image} height='200px' />
+							<img src={item.image} />
 							<h2 title={item.name}>{item.name}</h2>
 							<div className='playlist-buttons'>
 								<a href={item.url} target='_blank' title={`Open ${item.name} on Spotify`}>

--- a/src/components/SkipButton.jsx
+++ b/src/components/SkipButton.jsx
@@ -1,0 +1,5 @@
+import '../style/skipButton.scss';
+
+export default function SkipButton({ to, text }) {
+	return <a href={`#${to}`} className='skip-button'>{`Skip to ${text}`}</a>;
+}

--- a/src/components/Track.jsx
+++ b/src/components/Track.jsx
@@ -9,7 +9,7 @@ export default function track({ song }) {
 					<img src={song.image} />
 					<div>
 						<p>{song.name}</p>
-						<p>{song.artists.map((artist) => artist.name).join(', ')}</p>
+						<p>{song.artists?.map((artist) => artist.name).join(', ')}</p>
 					</div>
 				</a>
 			) : (

--- a/src/presenters/controlsPresenter.jsx
+++ b/src/presenters/controlsPresenter.jsx
@@ -27,7 +27,7 @@ export default function controlsPresenter(props) {
 	}, [props.model.loggedIn]);
 
 	return (
-		<section className='controls'>
+		<section className='controls' id='controls'>
 			<ShufflePresenter {...props} />
 			<div>
 				<CurrentTrackPresenter {...props} />

--- a/src/style/listScroller.scss
+++ b/src/style/listScroller.scss
@@ -32,7 +32,7 @@ ul.list-scroller {
 		& > img {
 			object-fit: cover;
 			height: 144px;
-			aspect-ratio: 1/1;
+			width: 144px;
 			background-image: url('/images/reShuffle-icon.svg');
 		}
 

--- a/src/style/skipButton.scss
+++ b/src/style/skipButton.scss
@@ -1,0 +1,19 @@
+@import './variables.scss';
+
+a.skip-button {
+	position: absolute;
+	color: transparent;
+	transform: translateX(-100%);
+
+	&:focus {
+		background-color: $primary;
+		color: $background;
+		font-weight: bold;
+		text-decoration: none;
+		border-radius: $radius;
+		padding: $margin-s $margin-m;
+		z-index: 2;
+		margin: 0 $margin-m;
+		transform: translateX(0);
+	}
+}

--- a/src/style/track.scss
+++ b/src/style/track.scss
@@ -21,7 +21,7 @@
 
 	img {
 		height: $playingImage;
-		aspect-ratio: 1/1;
+		width: $playingImage;
 		background-image: url('/images/reShuffle-icon.svg');
 	}
 

--- a/src/style/track.scss
+++ b/src/style/track.scss
@@ -22,6 +22,7 @@
 	img {
 		height: $playingImage;
 		aspect-ratio: 1/1;
+		background-image: url('/images/reShuffle-icon.svg');
 	}
 
 	div {

--- a/src/views/playlistsView.jsx
+++ b/src/views/playlistsView.jsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
 import ListScroller from '../components/ListScroller';
+import SkipButton from '../components/SkipButton';
 
 import '../style/playlist.scss';
 
@@ -32,6 +33,8 @@ export default function playerView(props) {
 					</svg>
 				</button>
 			</header>
+			<SkipButton to='short' text='Short Playlists' />
+			<SkipButton to='controls' text='Controls' />
 			<ListScroller
 				title='Long playlists'
 				data={props.playlists[0]}
@@ -39,6 +42,7 @@ export default function playerView(props) {
 				executing={props.executing}
 				addMore={true}
 				playlistButtonsDisabled={props.playlistButtonsDisabled}
+				id='long'
 			/>
 			<ListScroller
 				title='Short playlists'
@@ -47,6 +51,7 @@ export default function playerView(props) {
 				executing={props.executing}
 				addMore={true}
 				playlistButtonsDisabled={props.playlistButtonsDisabled}
+				id='short'
 			/>
 		</section>
 	);

--- a/src/views/playlistsView.jsx
+++ b/src/views/playlistsView.jsx
@@ -44,6 +44,7 @@ export default function playerView(props) {
 				playlistButtonsDisabled={props.playlistButtonsDisabled}
 				id='long'
 			/>
+			<SkipButton to='controls' text='Controls' />
 			<ListScroller
 				title='Short playlists'
 				data={props.playlists[1]}


### PR DESCRIPTION
- Add buttons to skip/jump to other parts of the website for keyboard users.
- Add null checks for tracks and playlists that don't load.

Also fixes the playlist image background and width/height instead of aspect ratio.

### How to test

- Go to the player
- Tab 3 times for the first tab button to show up