### PR TITLE
Only play first 778 songs to fix 413 when playing

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -126,6 +126,7 @@ export async function playPlaylist(uri, total, model) {
 	model.setControlButtonsDisabled(false);
 	try {
 		const { queue, uris } = await shuffle(uri.replace('spotify:playlist:', ''), total, model);
+		const songs = uris.splice(0, 778);
 		if (queue.length !== 0) {
 			const responseShuffle = await fetchUrl('player/shuffle?state=false', 'PUT');
 			if (responseShuffle.ok) {
@@ -133,7 +134,7 @@ export async function playPlaylist(uri, total, model) {
 					method: 'PUT',
 					headers: { Authorization: `Bearer ${token}` },
 					body: JSON.stringify({
-						uris: uris,
+						uris: songs,
 					}),
 				});
 				if (response.ok) {


### PR DESCRIPTION
Splice the playing output to only hold 778 songs to not get 413 To big payload when issuing the play request.
All songs are still being included in the shuffle part.

## How to test
Play a playlist of at least 779 songs.