### PR TITLE
Fix duplicate playlists and playlist images

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -43,16 +43,18 @@ export async function fetchPlaylists() {
 				} while (json.next && offset < 500);
 
 				const longPlaylists = lists
-					.filter((item) => item.tracks.total > 80)
-					.map((item) => mapPlaylists(item));
+					?.filter((item) => item.tracks.total > 80)
+					?.map((item) => mapPlaylists(item))
+					?.filter((song, index, list) => list.findIndex((s) => s.id === song.id) === index);
 				const shortPlaylists = lists
-					.filter((item) => item.tracks.total <= 80)
-					.map((item) => mapPlaylists(item));
+					?.filter((item) => item.tracks.total <= 80)
+					?.map((item) => mapPlaylists(item))
+					?.filter((song, index, list) => list.findIndex((s) => s.id === song.id) === index);
 
 				function mapPlaylists(item) {
 					return {
 						id: item.id,
-						image: item.images.length > 1 ? item.images[1]?.url : item.images[0]?.url,
+						image: item.images?.length > 1 ? item.images?.[1]?.url : item.images?.[0]?.url,
 						name: item.name,
 						tracks: item.tracks,
 						url: item.external_urls.spotify,

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,11 +6,12 @@ import { QueryClientProvider, QueryClient } from 'react-query';
 import model from './models/model.js';
 import App from './App.jsx';
 
-import "./style/main.scss"
+import './style/main.scss';
 
 configure({ enforceActions: 'never' });
 const reactiveModel = observable(model);
-window.model = reactiveModel
+
+if (import.meta.env.MODE === 'development') window.model = reactiveModel;
 
 export const queryClient = new QueryClient({
 	defaultOptions: {


### PR DESCRIPTION
Remove all duplicate playlists that Spotify's API might send.
Added null check if playlist images are not defined.
Also fixed so the model is only visible in the console while in development mode and not in production.