### PR TITLE
Disable controls when going to home page and back to player

### DIFF
--- a/src/presenters/controlsPresenter.jsx
+++ b/src/presenters/controlsPresenter.jsx
@@ -23,6 +23,7 @@ export default function controlsPresenter(props) {
 		return () => {
 			props.model.removePlayer();
 			spotifyPlayerScript.remove();
+			props.model.setControlButtonsDisabled(true);
 		};
 	}, [props.model.loggedIn]);
 


### PR DESCRIPTION
When going to the player for the first time the control buttons are disabled as before.

Now, if you go back to the home page by either pressing the reShuffle logo or using the back arrow and then going back to the player, they are disabled once again :)