### PR TITLE
Spread & Epic Shuffle updates

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -145,7 +145,9 @@ export async function playPlaylist(uri, total, model) {
 				model.setQueue(queue);
 			}
 		}
-	} catch (error) {}
+	} catch (error) {
+		console.error(error);
+	}
 	setTimeout(() => {
 		model.setExecutingPlay(false);
 		model.setExecutingNext(false);

--- a/src/shuffles.js
+++ b/src/shuffles.js
@@ -66,14 +66,41 @@ export function artistSpreadShuffle(tracks) {
 		//Spread the albums
 		shuffledGroups[artist] = spread(albumGroups, groups[artist].length);
 	}
-	const newOrderOfTracks = spread(shuffledGroups, tracks.length);
+	const spreadTracks = spread(shuffledGroups, tracks.length);
+
+	for (let i = 0; i < tracks.length - 2; i++) {
+		const currentArtists = spreadTracks[i].artists;
+		const nextArtists = spreadTracks[i + 1].artists;
+		const nextNextArtists = spreadTracks[i + 2].artists;
+
+		if (currentArtists.length < 2 && nextArtists.length < 2) continue;
+
+		//Check if next song have matching artists
+		if (
+			!currentArtists.some((artist) =>
+				nextArtists.some((nextArtist) => artist.id === nextArtist.id),
+			)
+		)
+			continue;
+
+		//Check if two songs forward have matching artists
+		if (
+			currentArtists.some((artist) =>
+				nextNextArtists.some((nextArtist) => artist.id === nextArtist.id),
+			)
+		)
+			continue;
+
+		//Swap the next two songs
+		[spreadTracks[i + 1], spreadTracks[i + 2]] = [spreadTracks[i + 2], spreadTracks[i + 1]];
+	}
 
 	//Create array of uris
-	const uris = newOrderOfTracks.map((track) => {
+	const uris = spreadTracks.map((track) => {
 		return track.uri;
 	});
 
-	return { queue: newOrderOfTracks, uris: uris };
+	return { queue: spreadTracks, uris: uris };
 }
 
 export async function epicShuffle(tracks) {

--- a/src/shuffles.js
+++ b/src/shuffles.js
@@ -58,9 +58,14 @@ export function artistSpreadShuffle(tracks) {
 
 	//Shuffle each group
 	const shuffledGroups = {};
-	for (const artist in groups)
-		shuffledGroups[artist] = groups[artist].sort((a, b) => 0.5 - Math.random()); //Use FYS here, or recursive
-
+	for (const artist in groups) {
+		//Group by album
+		const albumGroups = Object.groupBy(groups[artist], (track) => {
+			return track.album.name;
+		});
+		//Spread the albums
+		shuffledGroups[artist] = spread(albumGroups, groups[artist].length);
+	}
 	const newOrderOfTracks = spread(shuffledGroups, tracks.length);
 
 	//Create array of uris

--- a/src/shuffles.js
+++ b/src/shuffles.js
@@ -107,14 +107,10 @@ export async function epicShuffle(tracks) {
 		//Coordinates of currentlyPlaying song
 		//acousticness, danceability, energy, instrumentalness, liveness, mode, speechiness, valence, artist
 		const track1 = [
-			currentPlayingSong.acousticness,
 			currentPlayingSong.danceability,
-			currentPlayingSong.energy,
-			currentPlayingSong.instrumentalness,
-			currentPlayingSong.liveness,
+			currentPlayingSong.energy / 2,
 			currentPlayingSong.mode,
-			currentPlayingSong.speechiness,
-			currentPlayingSong.valence,
+			currentPlayingSong.valence / 2,
 			0,
 		];
 		let sum = 0;
@@ -122,14 +118,10 @@ export async function epicShuffle(tracks) {
 		//Calculate distances to remaining songs
 		weights = combinedData.map((audioFeaturesAndTrack, index) => {
 			const track2 = [
-				audioFeaturesAndTrack.acousticness,
 				audioFeaturesAndTrack.danceability,
-				audioFeaturesAndTrack.energy,
-				audioFeaturesAndTrack.instrumentalness,
-				audioFeaturesAndTrack.liveness,
+				audioFeaturesAndTrack.energy / 2,
 				audioFeaturesAndTrack.mode,
-				audioFeaturesAndTrack.speechiness,
-				audioFeaturesAndTrack.valence,
+				audioFeaturesAndTrack.valence / 2,
 				currentPlayingSong.artists[0].name === audioFeaturesAndTrack.artists[0].name ? 3 : 0,
 			];
 			const d = longestDistance - distance(track1, track2) + 0.3 * weights[index];

--- a/src/shuffles.js
+++ b/src/shuffles.js
@@ -23,7 +23,7 @@ export async function shuffle(id, total, model) {
 		case '4':
 			return pureRandomShuffle(tracks);
 		default:
-			return fisherYatesShuffle(tracks);
+			return artistSpreadShuffle(tracks);
 	}
 }
 

--- a/src/shuffles.js
+++ b/src/shuffles.js
@@ -52,7 +52,7 @@ function filterTracks(playlist, id) {
 
 export function artistSpreadShuffle(tracks) {
 	//Group by artist
-	const groups = Object.groupBy(tracks, (track, index) => {
+	const groups = Object.groupBy(tracks, (track) => {
 		return track.artists[0].name;
 	});
 


### PR DESCRIPTION
## Spread Shuffle
- Spread the songs based on albums within the artist groups.
- Spread secondary artists away from their own songs.

## Epic Shuffle
- Add v2
- Removed some attributes.
- Rebalanced remaining attributes.

## Other
- Fixed so the catched errors are console logged.
- Removed unused index variable.
- Fix so Shuffle 0 (Spread) is default instead of FYS.