### PR TITLE
Fix pure random bug

### DIFF
--- a/src/models/model.js
+++ b/src/models/model.js
@@ -26,6 +26,7 @@ export default {
 
 	shuffle: parseInt(localStorage.getItem('shuffle')) || 0,
 
+	tracks: [],
 	queue: [],
 	currentQueueTrack: 0,
 	currentPlaylistId: undefined,
@@ -222,6 +223,10 @@ export default {
 	setQueue(queue) {
 		this.queue = queue;
 		this.currentQueueTrack = 0;
+	},
+
+	setTracks(tracks) {
+		this.tracks = tracks;
 	},
 
 	setCurrentPlaylistId(id) {

--- a/src/shuffles.js
+++ b/src/shuffles.js
@@ -7,8 +7,9 @@ export async function shuffle(id, total, model) {
 		playlist = await fetchTracksOfPlaylist(id, total);
 		tracks = filterTracks(playlist, id);
 		model.setCurrentPlaylistId(id);
+		model.setTracks(tracks);
 	} else {
-		tracks = model.queue;
+		tracks = model.tracks;
 	}
 	if (total === 0) return { queue: [], uris: [] };
 	switch (localStorage.getItem('shuffle')) {


### PR DESCRIPTION
1. Added the tracks to the model
2. Before only the queue was stored in the model and when you shuffled the same playlist again it just reshuffled the queue. But if you shuffle with pure random the queue might get duplicates and therefore the other shuffles also get duplicates.

###Testing
1. Bossen already tested
2. Shuffle with pure random (5) first
3. Then shuffle the same playlist again with another shuffle
4. There should not be any duplicates